### PR TITLE
Update chartfooter.php

### DIFF
--- a/chartfooter.php
+++ b/chartfooter.php
@@ -61,10 +61,12 @@ $query="select start_datetime, stop_datetime from zone_log_view where (start_dat
 $results = $conn->query($query);
 $count=mysqli_num_rows($results); 
 while ($row = mysqli_fetch_assoc($results)) {
-	if((--$count)==0) break;
-$boiler_start = strtotime($row['start_datetime']) * 1000;
-$boiler_stop = strtotime($row['stop_datetime'])* 1000;
-echo "{ xaxis: { from: ".$boiler_stop.", to: ".$boiler_start." }, color: \"#ffe9dc\" },  \n" ;
+	if((--$count)==-1) break;
+	$boiler_start = strtotime($row['start_datetime']) * 1000;
+if (is_null($row['stop_datetime'])) {
+	$boiler_stop = strtotime("now") * 1000;
+} else {$boiler_stop = strtotime($row['stop_datetime']) * 1000;}
+	echo "{ xaxis: { from: ".$boiler_start.", to: ".$boiler_stop." }, color: \"#ffe9dc\" },  \n" ;
 } ?> ];
  
 var options_one = {


### PR DESCRIPTION
'break' on -1 seems to fix an issue where the markings were not displayed for the most recent 'boiler on' time - there may be a better way of doing this, but it seems to work. 
The "if (is_null)..." allows the most current boiler on time to be displayed, even if it's still running (ie the stop time is NULL) by 'faking' the stop time as 'now'.  
Switching $boiler_start & $boiler_stop in the from/to doesn't appear to make any difference to anything - it displays fine either way!?!  Flot is weird, sometimes.