### PR TITLE
Remove redundant column 'active' from 'holidays' table

### DIFF
--- a/MySQL_Database/pihome_mysql_database.sql
+++ b/MySQL_Database/pihome_mysql_database.sql
@@ -236,7 +236,6 @@ CREATE TABLE IF NOT EXISTS `holidays` (
   `status` tinyint(4) DEFAULT NULL,
   `start_date_time` datetime DEFAULT NULL,
   `end_date_time` datetime DEFAULT NULL,
-  `active` tinyint(4) DEFAULT NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=8 DEFAULT CHARSET=utf16 COLLATE=utf16_bin;
 


### PR DESCRIPTION
Small change to pihome_mysql_database.sql to remove redundant column 'active' from 'holidays' table