### PR TITLE
Coop start schedule   

### DIFF
--- a/MySQL_Database/MySQL_View.sql
+++ b/MySQL_Database/MySQL_View.sql
@@ -26,7 +26,7 @@ Drop View if exists schedule_daily_time_zone_view;
 CREATE VIEW schedule_daily_time_zone_view AS
 select ss.id as time_id, ss.status as time_status, sstart.start, send.end, sWeekDays.WeekDays,
 sdtz.sync as tz_sync, sdtz.id as tz_id, sdtz.status as tz_status,
-sdtz.zone_id, zone.index_id, zone.name as zone_name, zt.`type`, temperature, holidays_id
+sdtz.zone_id, zone.index_id, zone.name as zone_name, zt.`type`, temperature, holidays_id , coop
 from schedule_daily_time_zone sdtz
 join schedule_daily_time ss on sdtz.schedule_daily_time_id = ss.id
 join schedule_daily_time sstart on sdtz.schedule_daily_time_id = sstart.id

--- a/MySQL_Database/pihome_mysql_database.sql
+++ b/MySQL_Database/pihome_mysql_database.sql
@@ -455,6 +455,7 @@ CREATE TABLE IF NOT EXISTS `schedule_daily_time_zone` (
   `zone_id` int(11) DEFAULT NULL,
   `temperature` float NOT NULL DEFAULT 0,
   `holidays_id` int(11) DEFAULT NULL,
+  `coop` tinyint(4) NOT NULL DEFAULT 0,
   PRIMARY KEY (`id`),
   KEY `FK_schedule_daily_time_zone_schedule_daily_time` (`schedule_daily_time_id`),
   KEY `FK_schedule_daily_time_zone_zone` (`zone_id`),

--- a/cron/boiler.php
+++ b/cron/boiler.php
@@ -129,6 +129,8 @@ while ($row = mysqli_fetch_assoc($results)) {
 		$sch_start_time = $schedule['start'];
 		$sch_end_time = $schedule['end'];
 		$sch_c = $schedule['temperature'];
+		$sch_coop = $schedule['coop'];
+
 		if (isset($schedule['holidays_id'])) {
 			$sch_holidays = '1';
 		}
@@ -293,7 +295,8 @@ while ($row = mysqli_fetch_assoc($results)) {
 				if (($holidays_status=='0') || ($sch_holidays=='1')) {
 					if($boost_status=='0'){$zone_status="0"; $stop_cause="Boost Finished";
 						if ($night_climate_status =='0') {
-							if (($sch_status =='1') && ($zone_c < $target_c-$zone_sp_deadband)){$zone_status="1"; $start_cause="Schedule Started"; $expected_end_date_time=date('Y-m-d '.$sch_end_time.''); }
+							if (($sch_status =='1') && ($zone_c < $target_c-$zone_sp_deadband)&&(($sch_coop == 0)||($boiler_fire_status == "1"))){$zone_status="1"; $start_cause="Schedule Started"; $expected_end_date_time=date('Y-m-d '.$sch_end_time.''); }
+							if (($sch_status =='1') && ($zone_c < $target_c-$zone_sp_deadband)&&($sch_coop == 1)&&($boiler_fire_status == "0")){$zone_status="0"; $stop_cause="Coop Start Schedule Waiting for Boiler Start"; $expected_end_date_time=date('Y-m-d '.$sch_end_time.''); }
 							if (($sch_status =='1') && ($zone_c >= $target_c-$zone_sp_deadband) && ($zone_c < $target_c)){$zone_status=$zone_status_prev; $start_cause="Schedule Target Deadband"; $stop_cause="Schedule Target Deadband"; }
 							if (($sch_status =='1') && ($zone_c >= $target_c)){$zone_status="0"; $stop_cause="Schedule Target C Achieved"; }
 							if (($sch_status =='1') && ($override_status=='1') && ($zone_c < $target_c-$zone_sp_deadband)){$zone_status="1"; $start_cause="Schedule Override Started"; $expected_end_date_time=date('Y-m-d '.$sch_end_time.'');}

--- a/homelist.php
+++ b/homelist.php
@@ -163,6 +163,7 @@ while ($row = mysqli_fetch_assoc($results)) {
 	$start_time = $schedule['start'];
 	$end_time = $schedule['end'];
 	$schedule_c = $schedule['temperature'];
+	$schedule_coop = $schedule['coop'];
 	$sch_status = $schedule['time_status'];
   	if (isset($schedule['holidays_id'])) {
     		$sch_holidays = 1;
@@ -314,13 +315,20 @@ while ($row = mysqli_fetch_assoc($results)) {
                   $shcolor='';
                   $target=number_format(DispTemp($conn,$override_c),0) . '&deg;';
               }
-              else if (($sch_status == 1) && ($room_c < $schedule_c)) {
+              else if (($sch_status == 1) && ($room_c < $schedule_c) && (($schedule_coop == 0)||($fired_status == 1))) {
                   //We are scheduled and heating
                   $status='red';   
                   $shactive='ion-ios-clock-outline';
                   $shcolor='';
                   $target=number_format(DispTemp($conn,$schedule_c),0) . '&deg;';
               }
+              else if (($sch_status == 1) && ($room_c < $schedule_c)&&($schedule_coop == 1)&&($fired_status == 0)) {
+                  //We are coop scheduled and waiting for boiler start
+                  $status='blueinfo';   
+                  $shactive='ion-ios-clock-outline';
+                  $shcolor='orange';
+                  $target=number_format(DispTemp($conn,$schedule_c),0) . '&deg;';
+              }              
               else if (($sch_status == 1) && ($room_c >= $schedule_c)) {
                   //We are scheduled and heating
                   $status='orange';

--- a/schedule_add.php
+++ b/schedule_add.php
@@ -73,9 +73,10 @@ if (isset($_POST['submit'])) {
 	foreach($_POST['id'] as $id){
 		$id = $_POST['id'][$id];
 		$status = isset($_POST['status'][$id]) ? $_POST['status'][$id] : "0";
+		$coop = isset($_POST['coop'][$id]) ? $_POST['coop'][$id] : "0";
 		//$status = $_POST['status'][$id];
 		$temp=TempToDB($conn,$_POST['temp'][$id]);
-		$query = "INSERT INTO schedule_daily_time_zone(sync, `status`, schedule_daily_time_id, zone_id, temperature, holidays_id) VALUES ('0', '{$status}', '{$schedule_daily_time_id}','{$id}','".number_format($temp,1)."',{$holidays_id}); ";
+		$query = "INSERT INTO schedule_daily_time_zone(sync, `status`, schedule_daily_time_id, zone_id, temperature, holidays_id, coop) VALUES ('0', '{$status}', '{$schedule_daily_time_id}','{$id}','".number_format($temp,1)."',{$holidays_id},{$coop}); ";
 		$zoneresults = $conn->query($query);
 		//echo $query;
 		if ($zoneresults) {
@@ -148,7 +149,7 @@ $query = "select * from zone where status = 1 AND `purge`= 0 order by index_id a
 $results = $conn->query($query);
 while ($row = mysqli_fetch_assoc($results)) {
 ?>
-
+	<hr>
 	<input type="hidden" name="id[<?php echo $row["id"];?>]" value="<?php echo $row["id"];?>">
 
 	<div class="checkbox checkbox-default  checkbox-circle">
@@ -174,6 +175,11 @@ while ($row = mysqli_fetch_assoc($results)) {
 		$max = 80;
 	}
 	?>
+	<div class="checkbox checkbox-default  checkbox-circle">
+    <input id="coop<?php echo $row["id"];?>" class="styled" type="checkbox" name="coop[<?php echo $row["id"];?>]" value="1" >
+    <label for="coop<?php echo $row["id"];?>">Coop start</label>
+    <div class="help-block with-errors"></div></div>
+    
 	<div class="slidecontainer">
 		<h4><?php echo $lang['temperature']; ?>: <span id="val<?php echo $row["id"];?>"></span>&deg;</h4><br>
 		<input type="range" min="<?php echo $min; ?>" max="<?php echo $max; ?>" step="0.5" value="15.0" class="slider" id="bb<?php echo $row["id"];?>" name="temp[<?php echo $row["id"];?>]">

--- a/schedule_edit.php
+++ b/schedule_edit.php
@@ -82,8 +82,9 @@ if (isset($_POST['submit'])) {
 		$id = $_POST['id'][$id];
 		$status = isset($_POST['status'][$id]) ? $_POST['status'][$id] : "0";
 		$status = $_POST['status'][$id];
+		$coop = $_POST['coop'][$id];
 		$temp=TempToDB($conn,$_POST['temp'][$id]);
-		$query = "UPDATE schedule_daily_time_zone SET sync = '0', status = '{$status}', temperature = '" . number_format($temp,1) . "' WHERE id = '{$id}' LIMIT 1";
+		$query = "UPDATE schedule_daily_time_zone SET sync = '0', status = '{$status}', temperature = '" . number_format($temp,1) . "', coop = '{$coop}' WHERE id = '{$id}' LIMIT 1";
 		$zoneresults = $conn->query($query);
 	}
 }
@@ -153,6 +154,7 @@ $query = "select * from schedule_daily_time_zone_view where time_id = {$time_id}
 $results = $conn->query($query);
 while ($row = mysqli_fetch_assoc($results)) {
 ?>
+	<hr>
 	<input type="hidden" name="id[<?php echo $row["tz_id"];?>]" value="<?php echo $row["tz_id"];?>">
 
 	<div class="checkbox checkbox-default  checkbox-circle">
@@ -183,6 +185,11 @@ if($row['tz_status'] == 1){
 		$max = 80;
 	}
 	?>
+	<div class="checkbox checkbox-default  checkbox-circle">
+    <input id="coop<?php echo $row["tz_id"];?>" class="styled" type="checkbox" name="coop[<?php echo $row["tz_id"];?>]" value="1" <?php $check = ($row['coop'] == 1) ? 'checked' : ''; echo $check; ?> >
+    <label for="coop<?php echo $row["tz_id"];?>">Coop start</label>
+    <div class="help-block with-errors"></div></div>
+    
 	<div class="slidecontainer">
 		<h4><?php echo $lang['temperature']; ?>: <span id="val<?php echo $row["zone_id"];?>"></span>&deg;</h4><br>
 		<input type="range" min="<?php echo $min; ?>" max="<?php echo $max; ?>" step="0.5" value="<?php echo DispTemp($conn, $row['temperature']) ?>" class="slider" id="bb<?php echo $row["zone_id"];?>" name="temp[<?php echo $row["tz_id"];?>]">


### PR DESCRIPTION
#32

Added option for zone schedule with coop start (option per zone on schedule add/edit screen).
Coop start schedule won't start zone if boiler is not already running. If boiler is running and temperature is below setpoint minus deadband schedule will start the zone, after starting it operates as any other schedule and will stop the zone when setpoint temperature is reached.
Idea is that in the same schedule some zones will have coop start and some will have normal start, coop start zones will start only if some other zone runs boiler first.

To update existing database run code below in phpmyadmin :

ALTER TABLE `schedule_daily_time_zone` ADD `coop` tinyint(4) NOT NULL DEFAULT 0 AFTER `holidays_id`;

Drop View if exists schedule_daily_time_zone_view;
CREATE VIEW schedule_daily_time_zone_view AS
select ss.id as time_id, ss.status as time_status, sstart.start, send.end, sWeekDays.WeekDays,
sdtz.sync as tz_sync, sdtz.id as tz_id, sdtz.status as tz_status,
sdtz.zone_id, zone.index_id, zone.name as zone_name, zt.`type`, temperature, holidays_id , coop
from schedule_daily_time_zone sdtz
join schedule_daily_time ss on sdtz.schedule_daily_time_id = ss.id
join schedule_daily_time sstart on sdtz.schedule_daily_time_id = sstart.id
join schedule_daily_time send on sdtz.schedule_daily_time_id = send.id
join schedule_daily_time sWeekDays on sdtz.schedule_daily_time_id = sWeekDays.id
join zone on sdtz.zone_id = zone.id
join zone zt on sdtz.zone_id = zt.id
where sdtz.`purge` = '0' order by zone.index_id;
