### PR TITLE
Database Configuration

### DIFF
--- a/cron/serialgw.py
+++ b/cron/serialgw.py
@@ -38,7 +38,7 @@ import ConfigParser
 
 # Initialise the database access varables
 config = ConfigParser.ConfigParser()
-config.read('../st_inc/db_config.ini')
+config.read('/var/www/st_inc/db_config.ini')
 dbhost = config.get('db', 'hostname')
 dbuser = config.get('db', 'dbusername')
 dbpass = config.get('db', 'dbpassword')

--- a/cron/wifigw.py
+++ b/cron/wifigw.py
@@ -34,13 +34,13 @@ import ConfigParser
 # stty -F /dev/ttyUSB0 115200
 # cat /dev/ttyUSB0
 
-#PiHome Database Settings Variables 
-									
-									  
-dbhost = 'localhost'
-dbuser = 'root'
-dbpass = 'passw0rd'
-dbname = 'pihome'
+# Initialise the database access varables
+config = ConfigParser.ConfigParser()
+config.read('/var/www/st_inc/db_config.ini')
+dbhost = config.get('db', 'hostname')
+dbuser = config.get('db', 'dbusername')
+dbpass = config.get('db', 'dbpassword')
+dbname = config.get('db', 'dbname')
 
 con = mdb.connect(dbhost, dbuser, dbpass, dbname)
 cur = con.cursor()


### PR DESCRIPTION
wifigw.py and serialgw.py changed back to using db_config.ini but using absolute file location for the ini file, this way it works when initiated by the cron job