### PR TITLE
Cronjob settings menu updated. Checks if jobs are running.

### DIFF
--- a/model.php
+++ b/model.php
@@ -795,7 +795,6 @@ echo '</table></div>
     </div>
 </div>';
 
-
 //cronetab model
 echo '
 <div class="modal fade" id="cron_jobs" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true">


### PR DESCRIPTION
@pihome-shc 
Implemented some improvements to cron job menu.

Now you can see if jobs are running, last run time and errors if any.
Job interval is hardcoded, but could be moved to DB and in setup.php.
I see a lot of possible improvements, but that will take time.
No language translations added. Error messages could be polished more.

Cheers,
Mindaugas