### PR TITLE
Setup TimeZone, Language, Temperature Unit while executing setup.php

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 st_inc/db_config.ini
-st_inc/_config.inc.php
 logs/main.log

--- a/index.php
+++ b/index.php
@@ -119,8 +119,21 @@ require_once(__DIR__.'/st_inc/functions.php');
 				$_SESSION['user_id'] = $found_user['id'];
         		$_SESSION['username'] = $found_user['username'];
 				// add entry to database if login is success
-				$query = "INSERT INTO userhistory(username, password, date, audit, ipaddress) VALUES ('{$username}', '{$password}', '{$lastlogin}', 'Failed', '{$ip}')";
+				$query = "INSERT INTO userhistory(username, password, date, audit, ipaddress) VALUES ('{$username}', '{$password}', '{$lastlogin}', 'Successful', '{$ip}')";
 				$result = $conn->query($query);
+
+				// Set Language cookie if doesn't exist
+				if(!isset($_COOKIE['PiHomeLanguage'])) {
+					$query = "SELECT language FROM system;";
+					$result = $conn->query($query);
+					$row = mysqli_fetch_assoc($result);
+					if (mysqli_num_rows($result) == 1) {
+						$lang = $row['language'];
+						setcookie("PiHomeLanguage", $lang, time()+(3600*24*90));
+						header("Location: " . $_SERVER['HTTP_REFERER']);
+					}
+				}
+				
         		// Jump to secured page
         		//redirect_to('home.php?uid='.$_SESSION['user_id']);
 				if(isset($_SESSION['url'])) {

--- a/setup.php
+++ b/setup.php
@@ -79,13 +79,12 @@ if (!$db_selected) {
         $command.= "--password=". $dbpassword ." ";
 		$command.= $dbname;
 		$command.= " > " . $dumpfname;
-########		system($command);
+		system($command);
 		// compress sql file and unlink (delete) sql file after creating zip file. 
 		$zipfname = $dbname . "_" . date("Y-m-d_H-i-s").".zip";
 		echo "\033[36m".date('Y-m-d H:i:s'). "\033[0m - MySQL DataBase Compressing Dump File \033[41m".$dumpfname."\033[0m \n";
-########		$zip = new ZipArchive();
-########		if($zip->open($zipfname,ZIPARCHIVE::CREATE)){
-		if(1==2){
+		$zip = new ZipArchive();
+		if($zip->open($zipfname,ZIPARCHIVE::CREATE)){
 			$zip->addFile($dumpfname,$dumpfname);
 			$zip->close();
 			unlink($dumpfname);
@@ -94,8 +93,7 @@ if (!$db_selected) {
 }
 	echo "\033[36m".date('Y-m-d H:i:s'). "\033[0m - MySQL DataBase Importing SQL File to Database \n";
 	// Name of the file
-####	$filename = __DIR__.'/MySQL_Database/pihome_mysql_database.sql';
-	$filename='';
+	$filename = __DIR__.'/MySQL_Database/pihome_mysql_database.sql';
 	// Select database
 	mysqli_select_db($conn, $dbname) or die('Error Selecting MySQL Database: ' . mysqli_error($conn));
 	// Temporary variable, used to store current query

--- a/setup.php
+++ b/setup.php
@@ -79,12 +79,13 @@ if (!$db_selected) {
         $command.= "--password=". $dbpassword ." ";
 		$command.= $dbname;
 		$command.= " > " . $dumpfname;
-		system($command);
+########		system($command);
 		// compress sql file and unlink (delete) sql file after creating zip file. 
 		$zipfname = $dbname . "_" . date("Y-m-d_H-i-s").".zip";
 		echo "\033[36m".date('Y-m-d H:i:s'). "\033[0m - MySQL DataBase Compressing Dump File \033[41m".$dumpfname."\033[0m \n";
-		$zip = new ZipArchive();
-		if($zip->open($zipfname,ZIPARCHIVE::CREATE)){
+########		$zip = new ZipArchive();
+########		if($zip->open($zipfname,ZIPARCHIVE::CREATE)){
+		if(1==2){
 			$zip->addFile($dumpfname,$dumpfname);
 			$zip->close();
 			unlink($dumpfname);
@@ -93,7 +94,8 @@ if (!$db_selected) {
 }
 	echo "\033[36m".date('Y-m-d H:i:s'). "\033[0m - MySQL DataBase Importing SQL File to Database \n";
 	// Name of the file
-	$filename = __DIR__.'/MySQL_Database/pihome_mysql_database.sql';
+####	$filename = __DIR__.'/MySQL_Database/pihome_mysql_database.sql';
+	$filename='';
 	// Select database
 	mysqli_select_db($conn, $dbname) or die('Error Selecting MySQL Database: ' . mysqli_error($conn));
 	// Temporary variable, used to store current query
@@ -119,7 +121,7 @@ if (!$db_selected) {
 	echo "\033[36m".date('Y-m-d H:i:s'). "\033[0m - MySQL DataBase File \033[41m".$filename."\033[0m Imported Successfully \n";
 	//Table View 
 	echo "\033[36m".date('Y-m-d H:i:s'). "\033[0m - MySQL DataBase Creating Table View \n";
-	echo "\033[36m".date('Y-m-d H:i:s'). "\033[0m - Importing SQL Table View File to Database, This could take few minuts.  \n";
+	echo "\033[36m".date('Y-m-d H:i:s'). "\033[0m - MySQL DataBase Importing SQL Table View File to Database, This could take few minuts.  \n";
 	// Name of the file
 	$tableviewfilename = __DIR__.'/MySQL_Database/MySQL_View.sql';
 	// Select database
@@ -145,26 +147,7 @@ if (!$db_selected) {
 			}
 	}
 	
-	echo "\033[36m".date('Y-m-d H:i:s'). "\033[0m - DataBase File \033[41m".$tableviewfilename."\033[0m Imported Successfully \n";
-	echo "\033[36m".date('Y-m-d H:i:s'). "\033[0m - Creating Table View \n";
-
-//Add database settings to _config.inc.php
-$dbfilename = __DIR__.'/st_inc/_config.inc.php';
-$dbcontents = '<?php
-$hostname = \''.$hostname.'\';
-$dbname   = \''.$dbname.'\';
-$dbusername = \''.$dbusername.'\';
-$dbpassword = \''.$dbpassword.'\';
-$connect_error = \'Sorry We are Experiencing MySQL Database Connection Problem...\';
-?>
-';
-
-if (file_exists($dbfilename)) {
-	echo "\033[36m".date('Y-m-d H:i:s'). "\033[0m - MySQL DataBase Removing old Configuration file \033[41m ".$dbfilename." \033[0m \n";
-	unlink($dbfilename);
-}
-echo "\033[36m".date('Y-m-d H:i:s'). "\033[0m - MySQL DataBase Saving New Configuration file \033[41m ".$dbfilename." \033[0m \n";
-file_put_contents($dbfilename, $dbcontents, FILE_APPEND);
+	echo "\033[36m".date('Y-m-d H:i:s'). "\033[0m - MySQL DataBase DataBase File \033[41m".$tableviewfilename."\033[0m Imported Successfully \n";
 
 if (file_exists($cronfile)) {
 	echo "\033[36m".date('Y-m-d H:i:s'). "\033[0m - CronTab Removing old CronJobs File \033[41m ".$cronfile." \033[0m \n";
@@ -239,20 +222,236 @@ $message = '#
 #-------------------------------------------------------------------------
 ';
 
-//Save Existing CronJobs to File 
-file_put_contents($cronfile, $output);
-echo "\033[36m".date('Y-m-d H:i:s'). "\033[0m - CronTab Exiting CronJobs Saved to \033[41m ".$cronfile." \033[0m File. \n";
-
-//Append Temporary CronJobs File
-file_put_contents($cronfile, $message, FILE_APPEND);
-
-//Add CronJobs to CronTab
-echo exec('crontab '. $cronfile);	
-echo "\033[36m".date('Y-m-d H:i:s'). "\033[0m - CronTab CronJobs Added from \033[41m ".$cronfile." \033[0m File. \n";	
-
+if ($message==$output) {
+	echo "\033[36m".date('Y-m-d H:i:s'). "\033[0m - CronTab CronJobs Exist, No changes required \n";
+} else {
+	//Save Temporary CronJobs File
+	file_put_contents($cronfile, $message);
+	echo "\033[36m".date('Y-m-d H:i:s'). "\033[0m - CronTab CronJobs Added from \033[41m ".$cronfile." \033[0m File. \n";
+	//Append Existing CronJobs to File
+	file_put_contents($cronfile, $output, FILE_APPEND);
+	echo "\033[36m".date('Y-m-d H:i:s'). "\033[0m - CronTab Existing CronJobs Saved to \033[41m ".$cronfile." \033[0m File. \n";
+	//Add CronJobs to CronTab
+	echo exec('crontab '. $cronfile);
+	echo "\033[36m".date('Y-m-d H:i:s'). "\033[0m - \033[41mCronTab Make Sure no duplicate jobs running 'crontab -l' .\033[0m\n";
+}
+	
 if (file_exists($cronfile)) {
 	echo "\033[36m".date('Y-m-d H:i:s'). "\033[0m - CronTab Removing CronJobs File \033[41m ".$cronfile." \033[0m \n";
 	unlink($cronfile);
+}
+
+// 
+echo "\033[36m".date('Y-m-d H:i:s'). "\033[0m - Database and Crontab Setup Completed.\n\t\t\tDo you want to continue with Time Zone, Language and Temperature Unit setup?\n\t\t\tEnter 'y' to continue or 'n' to finish with setup.\n";
+$units = array('y' => 1, 'yes'=> 1, 'n'=> 0, 'no'=> 0);
+$correct = 0;
+while ($correct == 0) {
+	$tzinput = trim(fgets(STDIN));
+	$tzinput = strtolower($tzinput);
+	if (array_key_exists($tzinput, $units)) {
+		$tzname = $units[$tzinput];
+		$correct = 1;
+	} else {
+		echo "\033[36m".date('Y-m-d H:i:s'). "\033[0m - !!!Wrong value, enter yes or no!!!\n";
+	}
+}
+
+if ($tzname == 1) {
+	// Set Time Zone
+	echo "\033[36m".date('Y-m-d H:i:s'). "\033[0m - TimeZome Configuring Time Zone\n";
+	$timezones = array();
+	array_push($timezones, array('zone_name' =>   'Pacific/Midway'      , 'zone_info' => "(GMT-11:00) Midway Island"));
+	array_push($timezones, array('zone_name' =>   'US/Samoa'             , 'zone_info' => "(GMT-11:00) Samoa"));
+	array_push($timezones, array('zone_name' =>   'US/Hawaii'            , 'zone_info' => "(GMT-10:00) Hawaii"));
+	array_push($timezones, array('zone_name' =>   'US/Alaska'            , 'zone_info' => "(GMT-09:00) Alaska"));
+	array_push($timezones, array('zone_name' =>   'US/Pacific'           , 'zone_info' => "(GMT-08:00) Pacific Time (US &amp; Canada)"));
+	array_push($timezones, array('zone_name' =>   'America/Tijuana'      , 'zone_info' => "(GMT-08:00) Tijuana"));
+	array_push($timezones, array('zone_name' =>   'US/Arizona'           , 'zone_info' => "(GMT-07:00) Arizona"));
+	array_push($timezones, array('zone_name' =>   'US/Mountain'          , 'zone_info' => "(GMT-07:00) Mountain Time (US &amp; Canada)"));
+	array_push($timezones, array('zone_name' =>   'America/Chihuahua'    , 'zone_info' => "(GMT-07:00) Chihuahua"));
+	array_push($timezones, array('zone_name' =>   'America/Mazatlan'     , 'zone_info' => "(GMT-07:00) Mazatlan"));
+	array_push($timezones, array('zone_name' =>   'America/Mexico_City'  , 'zone_info' => "(GMT-06:00) Mexico City"));
+	array_push($timezones, array('zone_name' =>   'America/Monterrey'    , 'zone_info' => "(GMT-06:00) Monterrey"));
+	array_push($timezones, array('zone_name' =>   'Canada/Saskatchewan'  , 'zone_info' => "(GMT-06:00) Saskatchewan"));
+	array_push($timezones, array('zone_name' =>   'US/Central'           , 'zone_info' => "(GMT-06:00) Central Time (US &amp; Canada)"));
+	array_push($timezones, array('zone_name' =>   'US/Eastern'           , 'zone_info' => "(GMT-05:00) Eastern Time (US &amp; Canada)"));
+	array_push($timezones, array('zone_name' =>   'US/East-Indiana'      , 'zone_info' => "(GMT-05:00) Indiana (East)"));
+	array_push($timezones, array('zone_name' =>   'America/Bogota'       , 'zone_info' => "(GMT-05:00) Bogota"));
+	array_push($timezones, array('zone_name' =>   'America/Lima'         , 'zone_info' => "(GMT-05:00) Lima"));
+	array_push($timezones, array('zone_name' =>   'America/Caracas'      , 'zone_info' => "(GMT-04:30) Caracas"));
+	array_push($timezones, array('zone_name' =>   'Canada/Atlantic'      , 'zone_info' => "(GMT-04:00) Atlantic Time (Canada)"));
+	array_push($timezones, array('zone_name' =>   'America/La_Paz'       , 'zone_info' => "(GMT-04:00) La Paz"));
+	array_push($timezones, array('zone_name' =>   'America/Santiago'     , 'zone_info' => "(GMT-04:00) Santiago"));
+	array_push($timezones, array('zone_name' =>   'Canada/Newfoundland'  , 'zone_info' => "(GMT-03:30) Newfoundland"));
+	array_push($timezones, array('zone_name' =>   'America/Buenos_Aires' , 'zone_info' => "(GMT-03:00) Buenos Aires"));
+	array_push($timezones, array('zone_name' =>   'Greenland'            , 'zone_info' => "(GMT-03:00) Greenland"));
+	array_push($timezones, array('zone_name' =>   'Atlantic/Stanley'     , 'zone_info' => "(GMT-02:00) Stanley"));
+	array_push($timezones, array('zone_name' =>   'Atlantic/Azores'      , 'zone_info' => "(GMT-01:00) Azores"));
+	array_push($timezones, array('zone_name' =>   'Atlantic/Cape_Verde'  , 'zone_info' => "(GMT-01:00) Cape Verde Is."));
+	array_push($timezones, array('zone_name' =>   'Africa/Casablanca'    , 'zone_info' => "(GMT) Casablanca"));
+	array_push($timezones, array('zone_name' =>   'Europe/Dublin'        , 'zone_info' => "(GMT) Dublin"));
+	array_push($timezones, array('zone_name' =>   'Europe/Lisbon'        , 'zone_info' => "(GMT) Lisbon"));
+	array_push($timezones, array('zone_name' =>   'Europe/London'        , 'zone_info' => "(GMT) London"));
+	array_push($timezones, array('zone_name' =>   'Africa/Monrovia'      , 'zone_info' => "(GMT) Monrovia"));
+	array_push($timezones, array('zone_name' =>   'Europe/Amsterdam'     , 'zone_info' => "(GMT+01:00) Amsterdam"));
+	array_push($timezones, array('zone_name' =>   'Europe/Belgrade'      , 'zone_info' => "(GMT+01:00) Belgrade"));
+	array_push($timezones, array('zone_name' =>   'Europe/Berlin'        , 'zone_info' => "(GMT+01:00) Berlin"));
+	array_push($timezones, array('zone_name' =>   'Europe/Bratislava'    , 'zone_info' => "(GMT+01:00) Bratislava"));
+	array_push($timezones, array('zone_name' =>   'Europe/Brussels'      , 'zone_info' => "(GMT+01:00) Brussels"));
+	array_push($timezones, array('zone_name' =>   'Europe/Budapest'      , 'zone_info' => "(GMT+01:00) Budapest"));
+	array_push($timezones, array('zone_name' =>   'Europe/Copenhagen'    , 'zone_info' => "(GMT+01:00) Copenhagen"));
+	array_push($timezones, array('zone_name' =>   'Europe/Ljubljana'     , 'zone_info' => "(GMT+01:00) Ljubljana"));
+	array_push($timezones, array('zone_name' =>   'Europe/Madrid'        , 'zone_info' => "(GMT+01:00) Madrid"));
+	array_push($timezones, array('zone_name' =>   'Europe/Paris'         , 'zone_info' => "(GMT+01:00) Paris"));
+	array_push($timezones, array('zone_name' =>   'Europe/Prague'        , 'zone_info' => "(GMT+01:00) Prague"));
+	array_push($timezones, array('zone_name' =>   'Europe/Rome'          , 'zone_info' => "(GMT+01:00) Rome"));
+	array_push($timezones, array('zone_name' =>   'Europe/Sarajevo'      , 'zone_info' => "(GMT+01:00) Sarajevo"));
+	array_push($timezones, array('zone_name' =>   'Europe/Skopje'        , 'zone_info' => "(GMT+01:00) Skopje"));
+	array_push($timezones, array('zone_name' =>   'Europe/Stockholm'     , 'zone_info' => "(GMT+01:00) Stockholm"));
+	array_push($timezones, array('zone_name' =>   'Europe/Vienna'        , 'zone_info' => "(GMT+01:00) Vienna"));
+	array_push($timezones, array('zone_name' =>   'Europe/Warsaw'        , 'zone_info' => "(GMT+01:00) Warsaw"));
+	array_push($timezones, array('zone_name' =>   'Europe/Zagreb'        , 'zone_info' => "(GMT+01:00) Zagreb"));
+	array_push($timezones, array('zone_name' =>   'Europe/Athens'        , 'zone_info' => "(GMT+02:00) Athens"));
+	array_push($timezones, array('zone_name' =>   'Europe/Bucharest'     , 'zone_info' => "(GMT+02:00) Bucharest"));
+	array_push($timezones, array('zone_name' =>   'Africa/Cairo'         , 'zone_info' => "(GMT+02:00) Cairo"));
+	array_push($timezones, array('zone_name' =>   'Africa/Harare'        , 'zone_info' => "(GMT+02:00) Harare"));
+	array_push($timezones, array('zone_name' =>   'Europe/Helsinki'      , 'zone_info' => "(GMT+02:00) Helsinki"));
+	array_push($timezones, array('zone_name' =>   'Europe/Istanbul'      , 'zone_info' => "(GMT+02:00) Istanbul"));
+	array_push($timezones, array('zone_name' =>   'Asia/Jerusalem'       , 'zone_info' => "(GMT+02:00) Jerusalem"));
+	array_push($timezones, array('zone_name' =>   'Europe/Kiev'          , 'zone_info' => "(GMT+02:00) Kyiv"));
+	array_push($timezones, array('zone_name' =>   'Europe/Minsk'         , 'zone_info' => "(GMT+02:00) Minsk"));
+	array_push($timezones, array('zone_name' =>   'Europe/Riga'          , 'zone_info' => "(GMT+02:00) Riga"));
+	array_push($timezones, array('zone_name' =>   'Europe/Sofia'         , 'zone_info' => "(GMT+02:00) Sofia"));
+	array_push($timezones, array('zone_name' =>   'Europe/Tallinn'       , 'zone_info' => "(GMT+02:00) Tallinn"));
+	array_push($timezones, array('zone_name' =>   'Europe/Vilnius'       , 'zone_info' => "(GMT+02:00) Vilnius"));
+	array_push($timezones, array('zone_name' =>   'Asia/Baghdad'         , 'zone_info' => "(GMT+03:00) Baghdad"));
+	array_push($timezones, array('zone_name' =>   'Asia/Kuwait'          , 'zone_info' => "(GMT+03:00) Kuwait"));
+	array_push($timezones, array('zone_name' =>   'Africa/Nairobi'       , 'zone_info' => "(GMT+03:00) Nairobi"));
+	array_push($timezones, array('zone_name' =>   'Asia/Riyadh'          , 'zone_info' => "(GMT+03:00) Riyadh"));
+	array_push($timezones, array('zone_name' =>   'Europe/Moscow'        , 'zone_info' => "(GMT+03:00) Moscow"));
+	array_push($timezones, array('zone_name' =>   'Asia/Tehran'          , 'zone_info' => "(GMT+03:30) Tehran"));
+	array_push($timezones, array('zone_name' =>   'Asia/Baku'            , 'zone_info' => "(GMT+04:00) Baku"));
+	array_push($timezones, array('zone_name' =>   'Europe/Volgograd'     , 'zone_info' => "(GMT+04:00) Volgograd"));
+	array_push($timezones, array('zone_name' =>   'Asia/Muscat'          , 'zone_info' => "(GMT+04:00) Muscat"));
+	array_push($timezones, array('zone_name' =>   'Asia/Tbilisi'         , 'zone_info' => "(GMT+04:00) Tbilisi"));
+	array_push($timezones, array('zone_name' =>   'Asia/Yerevan'         , 'zone_info' => "(GMT+04:00) Yerevan"));
+	array_push($timezones, array('zone_name' =>   'Asia/Kabul'           , 'zone_info' => "(GMT+04:30) Kabul"));
+	array_push($timezones, array('zone_name' =>   'Asia/Karachi'         , 'zone_info' => "(GMT+05:00) Karachi"));
+	array_push($timezones, array('zone_name' =>   'Asia/Tashkent'        , 'zone_info' => "(GMT+05:00) Tashkent"));
+	array_push($timezones, array('zone_name' =>   'Asia/Kolkata'         , 'zone_info' => "(GMT+05:30) Kolkata"));
+	array_push($timezones, array('zone_name' =>   'Asia/Kathmandu'       , 'zone_info' => "(GMT+05:45) Kathmandu"));
+	array_push($timezones, array('zone_name' =>   'Asia/Yekaterinburg'   , 'zone_info' => "(GMT+06:00) Ekaterinburg"));
+	array_push($timezones, array('zone_name' =>   'Asia/Almaty'          , 'zone_info' => "(GMT+06:00) Almaty"));
+	array_push($timezones, array('zone_name' =>   'Asia/Dhaka'           , 'zone_info' => "(GMT+06:00) Dhaka"));
+	array_push($timezones, array('zone_name' =>   'Asia/Novosibirsk'     , 'zone_info' => "(GMT+07:00) Novosibirsk"));
+	array_push($timezones, array('zone_name' =>   'Asia/Bangkok'         , 'zone_info' => "(GMT+07:00) Bangkok"));
+	array_push($timezones, array('zone_name' =>   'Asia/Jakarta'         , 'zone_info' => "(GMT+07:00) Jakarta"));
+	array_push($timezones, array('zone_name' =>   'Asia/Krasnoyarsk'     , 'zone_info' => "(GMT+08:00) Krasnoyarsk"));
+	array_push($timezones, array('zone_name' =>   'Asia/Chongqing'       , 'zone_info' => "(GMT+08:00) Chongqing"));
+	array_push($timezones, array('zone_name' =>   'Asia/Hong_Kong'       , 'zone_info' => "(GMT+08:00) Hong Kong"));
+	array_push($timezones, array('zone_name' =>   'Asia/Kuala_Lumpur'    , 'zone_info' => "(GMT+08:00) Kuala Lumpur"));
+	array_push($timezones, array('zone_name' =>   'Australia/Perth'      , 'zone_info' => "(GMT+08:00) Perth"));
+	array_push($timezones, array('zone_name' =>   'Asia/Singapore'       , 'zone_info' => "(GMT+08:00) Singapore"));
+	array_push($timezones, array('zone_name' =>   'Asia/Taipei'          , 'zone_info' => "(GMT+08:00) Taipei"));
+	array_push($timezones, array('zone_name' =>   'Asia/Ulaanbaatar'     , 'zone_info' => "(GMT+08:00) Ulaan Bataar"));
+	array_push($timezones, array('zone_name' =>   'Asia/Urumqi'          , 'zone_info' => "(GMT+08:00) Urumqi"));
+	array_push($timezones, array('zone_name' =>   'Asia/Irkutsk'         , 'zone_info' => "(GMT+09:00) Irkutsk"));
+	array_push($timezones, array('zone_name' =>   'Asia/Seoul'           , 'zone_info' => "(GMT+09:00) Seoul"));
+	array_push($timezones, array('zone_name' =>   'Asia/Tokyo'           , 'zone_info' => "(GMT+09:00) Tokyo"));
+	array_push($timezones, array('zone_name' =>   'Australia/Adelaide'   , 'zone_info' => "(GMT+09:30) Adelaide"));
+	array_push($timezones, array('zone_name' =>   'Australia/Darwin'     , 'zone_info' => "(GMT+09:30) Darwin"));
+	array_push($timezones, array('zone_name' =>   'Asia/Yakutsk'         , 'zone_info' => "(GMT+10:00) Yakutsk"));
+	array_push($timezones, array('zone_name' =>   'Australia/Brisbane'   , 'zone_info' => "(GMT+10:00) Brisbane"));
+	array_push($timezones, array('zone_name' =>   'Australia/Canberra'   , 'zone_info' => "(GMT+10:00) Canberra"));
+	array_push($timezones, array('zone_name' =>   'Pacific/Guam'         , 'zone_info' => "(GMT+10:00) Guam"));
+	array_push($timezones, array('zone_name' =>   'Australia/Hobart'     , 'zone_info' => "(GMT+10:00) Hobart"));
+	array_push($timezones, array('zone_name' =>   'Australia/Melbourne'  , 'zone_info' => "(GMT+10:00) Melbourne"));
+	array_push($timezones, array('zone_name' =>   'Pacific/Port_Moresby' , 'zone_info' => "(GMT+10:00) Port Moresby"));
+	array_push($timezones, array('zone_name' =>   'Australia/Sydney'     , 'zone_info' => "(GMT+10:00) Sydney"));
+	array_push($timezones, array('zone_name' =>   'Asia/Vladivostok'     , 'zone_info' => "(GMT+11:00) Vladivostok"));
+	array_push($timezones, array('zone_name' =>   'Asia/Magadan'         , 'zone_info' => "(GMT+12:00) Magadan"));
+	array_push($timezones, array('zone_name' =>   'Pacific/Auckland'     , 'zone_info' => "(GMT+12:00) Auckland"));
+	array_push($timezones, array('zone_name' =>   'Pacific/Fiji'         , 'zone_info' => "(GMT+12:00) Fiji"));
+	$zoneid=1;
+	echo "TZ ID\t TZ Information\n";
+	foreach($timezones as $timezone) {
+		echo $zoneid."\t".$timezone['zone_info']."\n";
+		$zoneid +=1;
+	}
+	echo "\033[36m".date('Y-m-d H:i:s'). "\033[0m - TimeZone !!!Please Enter Time Zone ID and press Enter!!!\n";
+	$correct = 0;
+	while ($correct == 0) {
+		$tzinput = trim(fgets(STDIN));
+		if (array_key_exists($tzinput-1, $timezones)) {
+			$tzname = $timezones[$tzinput-1]['zone_name'];
+			echo exec("timedatectl set-timezone $tzname");
+			echo "\033[36m".date('Y-m-d H:i:s'). "\033[0m - TimeZone Updated System Time Zone to \033[41m".$tzname."\033[0m.\n";
+			$query = "UPDATE `system` SET `timezone`='" . $tzname . "';";
+			$conn->query($query) or print("MySQL Database Error with Query ".$query.":". mysqli_error($conn)."\n");
+			echo "\033[36m".date('Y-m-d H:i:s'). "\033[0m - TimeZone Updated Database Value to \033[41m".$tzname."\033[0m.\n";
+			$correct = 1;
+		} else {
+			echo "\033[36m".date('Y-m-d H:i:s'). "\033[0m - TimeZone !!!Wrong value, IDs 1 to 112!!!\n";
+		}
+	}
+
+	// Set Language
+	if ($handle = opendir('/var/www/languages')) {
+		echo "\033[36m".date('Y-m-d H:i:s'). "\033[0m - Language Setting Up PIHome Language\n";
+		echo "\033[36m".date('Y-m-d H:i:s'). "\033[0m - Language Listing all available languages:\n";
+		$lnglist = array();
+		while (false !== ($entry = readdir($handle))) {
+			if ($entry != "." && $entry != "..") {
+				$entry=basename($entry,".php");
+				array_push($lnglist, $entry);
+			}
+		}
+		closedir($handle);
+		sort($lnglist);
+		$zoneid=1;
+		echo "ID\tLanguage\n";
+		foreach($lnglist as $item) {
+			echo $zoneid."\t".$item."\n";
+			$zoneid +=1;
+		}
+	}
+	echo "\033[36m".date('Y-m-d H:i:s'). "\033[0m - Language !!!Please Enter Language ID and press Enter!!!\n";
+	$correct = 0;
+	while ($correct == 0) {
+		$tzinput = trim(fgets(STDIN));
+		if (array_key_exists($tzinput-1, $lnglist)) {
+			$tzname = $lnglist[$tzinput-1];
+			$query = "UPDATE `system` SET `language`='" . $tzname . "';";
+			$conn->query($query) or print("MySQL Database Error with Query ".$query.":". mysqli_error($conn)."\n");
+			echo "\033[36m".date('Y-m-d H:i:s'). "\033[0m - Language Updated Database Value to \033[41m".$tzname."\033[0m.\n";
+			$correct = 1;
+		} else {
+			$zoneid=count($lnglist);
+			echo "\033[36m".date('Y-m-d H:i:s'). "\033[0m - Language !!!Wrong value, IDs 1 to $zoneid!!!\n";
+		}
+	}
+
+	// Set Temperature Unit
+	echo "\033[36m".date('Y-m-d H:i:s'). "\033[0m - Temperature Unit Setup\n";
+	$units = array('Celsius', 'Fahrenheit');
+	echo "ID\tUnit\n";
+	echo "1\t".$units[0]."\n";
+	echo "2\t".$units[1]."\n";
+	echo "\033[36m".date('Y-m-d H:i:s'). "\033[0m - Temperature Unit !!!Please Enter Temperature Unit ID and press Enter!!!\n";
+	$correct = 0;
+	while ($correct == 0) {
+		$tzinput = trim(fgets(STDIN));
+		if (array_key_exists($tzinput-1, $units)) {
+			$tzname = $units[$tzinput-1];
+			$query = "UPDATE `system` SET `c_f`='" . $tzname . "';";
+			$conn->query($query) or print("MySQL Database Error with Query ".$query.":". mysqli_error($conn)."\n");
+			echo "\033[36m".date('Y-m-d H:i:s'). "\033[0m - Temperature Unit Updated Database Value to \033[41m".$tzname."\033[0m.\n";
+			$correct = 1;
+		} else {
+			echo "\033[36m".date('Y-m-d H:i:s'). "\033[0m - Temperature Unit !!!Wrong value, IDs 1 and 2!!!\n";
+		}
+	}
+
 }
 
 echo "---------------------------------------------------------------------------------------- \n";

--- a/st_inc/_config.inc.php
+++ b/st_inc/_config.inc.php
@@ -1,8 +1,0 @@
-<?php
-$hostname = 'localhost';
-$dbname   = 'pihome';
-$dbusername = 'pihomedbadmin';
-$dbpassword = 'pihome2018';
-$connect_error = 'Sorry We are experiencing connection Problem...';
-
-?>

--- a/st_inc/sample_config.inc.php
+++ b/st_inc/sample_config.inc.php
@@ -1,9 +1,0 @@
-/* rename this file to _config.inc.php and correct the connection details below  and remove this line*/
-<?php
-$hostname = 'localhost';
-$dbname   = 'pihome';
-$dbusername = 'pihomedbadmin';
-$dbpassword = 'pihome2018';
-$connect_error = 'Sorry We are experiencing connection Problem...';
-
-?>


### PR DESCRIPTION
Now while executing setup.php you can setup:

- System TimeZone,
- PIHome Language
- PIHome Temperature Unit

Deleted `st_inc/_config.inc.php` as it is not used anywhere. Replaced by `st_inc/db_config.ini`.

If language cookie is not set when logging in, language is puled from DB and cookie set - `index.php`.

What about these suggestions?:
- Remove language options from here (as it is getting crowded and language usually is only changed once):
![2020-02-24_19-09-47](https://user-images.githubusercontent.com/5328862/75182916-4aecb280-5739-11ea-9728-01752fa91397.png)

- In settings model/Languages all languages could be auto populated from languages folder by matching country code to country list array.

- populate languages in login screen like this (to save space as more languages are added):
![2020-02-24_19-22-35](https://user-images.githubusercontent.com/5328862/75183753-11b54200-573b-11ea-829a-de2518a4a41d.png)


