### PR TITLE
Home Assistant integration

### DIFF
--- a/api/getBoiler.php
+++ b/api/getBoiler.php
@@ -1,0 +1,48 @@
+<?php
+/*
+   _____    _   _    _
+  |  __ \  (_) | |  | |
+  | |__) |  _  | |__| |   ___    _ __ ___     ___
+  |  ___/  | | |  __  |  / _ \  | |_  \_ \   / _ \
+  | |      | | | |  | | | (_) | | | | | | | |  __/
+  |_|      |_| |_|  |_|  \___/  |_| |_| |_|  \___|
+
+     S M A R T   H E A T I N G   C O N T R O L
+
+*************************************************************************"
+* PiHome is Raspberry Pi based Central Heating Control systems. It runs *"
+* from web interface and it comes with ABSOLUTELY NO WARRANTY, to the   *"
+* extent permitted by applicable law. I take no responsibility for any  *"
+* loss or damage to you or your property.                               *"
+* DO NOT MAKE ANY CHANGES TO YOUR HEATING SYSTEM UNTILL UNLESS YOU KNOW *"
+* WHAT YOU ARE DOING                                                    *"
+*************************************************************************"
+*/
+
+header("Access-Control-Allow-Origin: *");
+header("Content-Type: application/json; charset=UTF-8");
+header("Access-Control-Allow-Methods: GET, POST");
+header("Access-Control-Max-Age: 3600");
+header("Access-Control-Allow-Headers: Content-Type, Access-Control-Allow-Headers, Authorization, X-Requested-With");
+
+require_once(__DIR__.'../../st_inc/connection.php');
+require_once(__DIR__.'../../st_inc/functions.php');
+
+$query = "SELECT * FROM boiler_logs ORDER BY id desc LIMIT 1;";
+$results = $conn->query($query);
+$row = mysqli_fetch_assoc($results);
+if(! $row) {
+	http_response_code(400);
+	echo json_encode(array("success" => False, "state" => "No data found"));
+} else {
+	$stop_time=$row['stop_datetime'];
+	if($stop_time == "") {
+		http_response_code(200);
+		echo json_encode(array("success" => TRUE, "state" => "ON"));
+	} else {
+		http_response_code(200);
+		echo json_encode(array("success" => TRUE, "state" => "OFF"));
+	}
+}
+?>
+

--- a/api/getTemperature.php
+++ b/api/getTemperature.php
@@ -48,10 +48,23 @@ if(isset($_GET['zonename'])) {
                 	http_response_code(400);
                 	echo json_encode(array("success" => False, "state" => "Sensor has not reported in the last 24 hours."));
         	} else {
-		        $zone_c = $sensor['payload'];
-        		http_response_code(200);
-        		echo json_encode(array("success" => True, "state" => $zone_c));
-		}
+		        $zone_temp = $sensor['payload'];
+				$zone_time = $sensor['datetime'];
+
+				//query to get battery info from nodes_battery table
+				$query = "SELECT * FROM nodes_battery WHERE node_id = '{$zone_sensor_id}' ORDER BY id desc LIMIT 1;";
+				$result = $conn->query($query);
+				$node = mysqli_fetch_array($result);
+				if(! $node) {
+                	http_response_code(200);
+        			echo json_encode(array("success" => True, "state" => $zone_temp, "datetime" => $zone_time));
+				} else {
+					$zone_bat_voltage = $node['bat_voltage'];
+					$zone_bat_level = $node['bat_level'];
+        			http_response_code(200);
+        			echo json_encode(array("success" => True, "state" => $zone_temp, "datetime" => $zone_time, "bat_voltage" => $zone_bat_voltage, "bat_level" => $zone_bat_level));
+				}
+			}
 	}
 } else {
         http_response_code(400);


### PR DESCRIPTION
I made some changes to the API to allow a better integration with Home Assistant. The idea is for PiHome to still run the whole logic but to be able to monitor the status from Home Assistant.

- getTemperature.php has been changed to return also the sensor battery status, it now returns:
`{"success":true,"state":"19.00","datetime":"2021-02-28 15:23:34","bat_voltage":"2.50","bat_level":"43.00"}`

- getBoiler.php has been added to return the boiler status:
`{"success":true,"state":"OFF"}`

This allows the temperature of the zones, boiler status and battery info to be monitored from a dashboard in Home Assistant. In addition, the Zone Boost can be triggered from the Home Assistant dashboard. 

I can write a little how to on how to setup the Home Assistant side to work with this.